### PR TITLE
Remove stock lights from Utility category

### DIFF
--- a/Patches/MM-StockLights.cfg
+++ b/Patches/MM-StockLights.cfg
@@ -1,5 +1,6 @@
 @PART[spotLight1,spotLight2]:NEEDS[SurfaceLights]
 {
+	@category = none
 	@MODULE[ModuleLight]
 	{
 		@name = ModuleStockLightColoredLens


### PR DESCRIPTION
Since the surface-mounted lights mod adds a lights category with the stock lights, I removed them from the utility category so the parts are not present in two locations